### PR TITLE
add L2 compatible block info funcs

### DIFF
--- a/src/contracts/blocktime.go
+++ b/src/contracts/blocktime.go
@@ -11,7 +11,7 @@ import (
 )
 
 func FindBlockWithTs(client *ethclient.Client, ts uint64) (uint64, uint64, error) {
-	blockB, err := client.BlockByNumber(context.Background(), nil)
+	blockB, err := BlockByNumberL2Compat(client, context.Background(), nil)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -32,7 +32,7 @@ func FindBlockWithTs(client *ethclient.Client, ts uint64) (uint64, uint64, error
 		}
 		numA = numB - timeBack
 		numABig := big.NewInt(int64(numA))
-		blockA, err := client.BlockByNumber(context.Background(), numABig)
+		blockA, err := BlockByNumberL2Compat(client, context.Background(), numABig)
 		numCalls++
 		if err != nil {
 			return 0, 0, errors.New("RPC issue in FindBlockFromTs:" + err.Error())
@@ -59,7 +59,7 @@ func binSearch(client *ethclient.Client, numA uint64, tsA uint64, numB uint64, t
 	for {
 		numP = (numA + numB) / 2
 		numPBig := big.NewInt(int64(numP))
-		blockP, err := client.BlockByNumber(context.Background(), numPBig)
+		blockP, err := BlockByNumberL2Compat(client, context.Background(), numPBig)
 		numCalls++
 		if err != nil {
 			return 0, 0, numCalls, errors.New("RPC issue in FindBlockFromTs(search):" + err.Error())

--- a/src/contracts/l2_compat.go
+++ b/src/contracts/l2_compat.go
@@ -1,0 +1,70 @@
+package contracts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// BlockByHashL2Compat is L2 compatible version of ethclient.Client.BlockByHash. It
+// retrieves block header information only. Transactions information is not
+// parsed due to go-etheruem's L2 incompatibility. Use it when getting block
+// info fails with "invalid transaction type" error.
+func BlockByHashL2Compat(c *ethclient.Client, ctx context.Context, hash common.Hash) (*types.Block, error) {
+	return getL2CompatibleBlockHeader(c, ctx, "eth_getBlockByHash", hash, true)
+}
+
+// BlockByNumberL2Compat is L2 compatible version of ethclient.Client.BlockByNumber. It
+// retrieves block header information only. Transactions information is not
+// parsed due to go-etheruem's L2 incompatibility. Use it when getting block
+// info fails with "invalid transaction type" error.
+func BlockByNumberL2Compat(c *ethclient.Client, ctx context.Context, number *big.Int) (*types.Block, error) {
+	return getL2CompatibleBlockHeader(c, ctx, "eth_getBlockByNumber", toBlockNumArg(number), true)
+}
+
+// getL2CompatibleBlockHeader queries given c RPC endpoint for block header
+// information. This method is compatible with L2 chains for retrieving block
+// info, but it does not parse transaction information, therefore, only block
+// header information is available in returned *types.Block.
+func getL2CompatibleBlockHeader(c *ethclient.Client, ctx context.Context, method string, args ...any) (*types.Block, error) {
+	var raw json.RawMessage
+	err := c.Client().CallContext(ctx, &raw, method, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decode header only.
+	var head *types.Header
+	if err := json.Unmarshal(raw, &head); err != nil {
+		return nil, err
+	}
+	// When the block is not found, the API returns JSON null.
+	if head == nil {
+		return nil, ethereum.NotFound
+	}
+
+	return types.NewBlockWithHeader(head), nil
+}
+
+func toBlockNumArg(number *big.Int) string {
+	if number == nil {
+		return "latest"
+	}
+	if number.Sign() >= 0 {
+		return hexutil.EncodeBig(number)
+	}
+	// It's negative.
+	if number.IsInt64() {
+		return rpc.BlockNumber(number.Int64()).String()
+	}
+	// It's negative and large, which is invalid.
+	return fmt.Sprintf("<invalid %d>", number)
+}


### PR DESCRIPTION
On arbitrum there are additional transaction types available (with additional L2 specific info) which are not supported by go-ethereum (https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L43-L56 vs https://github.com/ethereum/go-ethereum/blob/master/core/types/transaction.go#L47-L52). Because of this, when BlockByNumber/BlockByHash methods are queried with go-ethereum's `ethclient.Client`, transaction list unmarshaling fails with `transaction type not supported` 

This PR introduces 2 methods for querying block information on L2 chains which have non-standard tx types in json-rpc response. `contracts.BlockByHashL2Compat` and `contracts.BlockByNumberL2Compat` work exactly like their `ethclient.Client` counterparts, except they only parse the block header information.
